### PR TITLE
Remove [New!] tag from Jerma Subtitle Search

### DIFF
--- a/public/content.json
+++ b/public/content.json
@@ -26,7 +26,7 @@
           "url": "clips.jerma.io"
         },
         {
-          "title": "[New!] Jerma Subtitle Search",
+          "title": "Jerma Subtitle Search",
           "description": "Search through everything Jerma has verbally said online.",
           "authors": [
             {
@@ -228,7 +228,7 @@
           "url": "observing.jerma.io"
         },
         {
-          "title": "[New!] Jerma Subtitle Search",
+          "title": "Jerma Subtitle Search",
           "description": "Search through everything Jerma has verbally said online.",
           "authors": [
             {


### PR DESCRIPTION
It's been like a month and a half since it was added - still relatively new but figured the tag should probably be removed sometime.